### PR TITLE
TECH-47 refactor: decoupled a Researcher from an optionally associated Lab

### DIFF
--- a/src/data/researchers.ts
+++ b/src/data/researchers.ts
@@ -3,11 +3,15 @@ export interface IResearcher { // researcher properties
     email: string;
     image: string;
     googleScholarLink: string; // link to google scholar
-    labName: string;
-    labWebsite?: string;    // optional link to lab website
-    labDescription: string;
+    lab?: ILab; 
     researchInterests: string[];
     researchTopic: string; // current research topic
     acceptingStudents: boolean;
     minStudentRequirements: string[];
+}
+
+export interface ILab {
+  name: string;
+  website?: string;
+  description: string;
 }


### PR DESCRIPTION
Made a ILab interface for an IResearcher to reference to remove duplicate data.

In the future we could add more data to a Lab such as relevant topics to it, but for current purposes this should work.

I am open to any fields that wish to be added now though!

Closes TECH-47