### PR TITLE
Tech 51 add mobile style for researcher card

### DIFF
--- a/src/components/researcher-card.tsx
+++ b/src/components/researcher-card.tsx
@@ -52,7 +52,7 @@ export default function ResearcherCard({
                     {researcher?.researchInterests.map((interest, index) => (
                     <li
                         key={index}
-                        className={`relative pl-4 text-sm truncate before:content-['•'] before:absolute before:left-0 before:text-white sm:block ${index >= 2 ? 'hidden' : ''}`}
+                        className={`relative pl-4 text-sm truncate before:content-['•'] before:absolute before:left-0 before:text-white ${index >= 2 ? 'hidden' : ''}`}
                     >
                         {interest}
                     </li>
@@ -64,7 +64,7 @@ export default function ResearcherCard({
                     {researcher.minStudentRequirements.map((requirement, index) => (
                         <li
                             key={index}
-                            className={`relative pl-4 text-sm truncate before:content-['•'] before:absolute before:left-0 before:text-white sm:block ${index >= 2 ? 'hidden' : ''}`}
+                            className={`relative pl-4 text-sm truncate before:content-['•'] before:absolute before:left-0 before:text-white ${index >= 2 ? 'hidden' : ''}`}
                         >
                             {requirement}
                         </li>


### PR DESCRIPTION
## Description:
- limit bullet point for "Research Interests", "Student Requirements" up to 2 **across all screen size**
 
The following change has been made for a mobile device size less than 640px, [prefixed as "sm" in tailwind.](https://tailwindcss.com/docs/responsive-design)
- flex direction is a column (picture appear top description appear bottom instead of left/right)

## Images of the changes, if applicable:
Before
<img width="502" height="663" alt="before" src="https://github.com/user-attachments/assets/c7353dd5-22d9-40b2-a243-081a2b5335fd" />

After
<img width="782" height="802" alt="after" src="https://github.com/user-attachments/assets/ecaf34cd-78a1-45e1-b533-bd68b5bdf3b4" />
