### PR TITLE
TECH-64 Pin the X button to the top of researcher-modal

### DIFF
--- a/src/components/researcher-modal.tsx
+++ b/src/components/researcher-modal.tsx
@@ -75,7 +75,7 @@ export default function ResearcherModal({
                             <FaTimes />
                         </button>
                     </div>
-                    <div className="p-6">
+                    <div className="pl-6 pr-6 pb-11">
                         <motion.div
                             key="modal-content"
                             initial={{ opacity: 0, y: 10 }}


### PR DESCRIPTION
[Original Jira link](https://manitobacssa.atlassian.net/jira/software/projects/TECH/boards/2?selectedIssue=TECH-64)

## Description
[In researcher modal](https://www.umanitobacssa.ca/resources/researchers), when there's too many content within modal that it starts generating scrollbar, "X" button disappear (especially for mobile)

### Before
https://github.com/user-attachments/assets/15213007-a77b-40fb-b137-7ca7907f7c93

So I added sticky positioning which allows the button to stick in certain position no matter the scroll position

### After
https://github.com/user-attachments/assets/d0b8056b-6e5d-4388-a1a9-a264da1d5ae0


