### PR TITLE
Tech 67 fix uneven padding for researcher modal

### DIFF
--- a/src/components/researcher-modal.tsx
+++ b/src/components/researcher-modal.tsx
@@ -125,7 +125,7 @@ export default function ResearcherModal({
                                 </div>
 
                                 <div className="flex flex-col gap-4 pt-5 lg:pt-0 lg:pl-5">
-                                    <div className="pr-3 overflow-hidden">
+                                    <div className="overflow-hidden">
                                         <p className="text-lg font-bold">Lab Description</p>
                                         {researcher.lab?.description && <p className="text-sm break-words whitespace-pre-line">{researcher.lab?.description}</p>}
                                     </div>


### PR DESCRIPTION
### Jira Ticket
[Fix uneven padding for researcher modal](https://manitobacssa.atlassian.net/browse/TECH-67)

### Description
Now it no longer has a right-padding

<img width="737" height="721" alt="image" src="https://github.com/user-attachments/assets/50da0bba-5ee5-49dd-b561-5b6e16124c86" />
