### PR TITLE
Refactor component into having dynamic href instead of hardcoded value [skip-ci]

### DIFF
--- a/src/components/guides/guide-card.tsx
+++ b/src/components/guides/guide-card.tsx
@@ -4,17 +4,17 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 interface GuideCardProps {
   title: string;
   description: string;
-  slug: string;
   author?: string;
   date?: string;
+  href: string;
 }
 
 const GuideCard: React.FC<GuideCardProps> = ({
   title,
   description,
-  slug,
   author,
-  date
+  date,
+  href
 }) => {
   // Format date if available
   const formattedDate = date ? new Date(date).toLocaleDateString('en-US', {
@@ -24,7 +24,7 @@ const GuideCard: React.FC<GuideCardProps> = ({
   }) : null;
 
   return (
-    <Link href={`/resources/guides/${slug}`} className="block h-full">
+    <Link href={href} className="block h-full">
       <Card className="h-full transition-shadow hover:shadow-md">
         <CardHeader>
           <CardTitle className="text-xl">{title}</CardTitle>

--- a/src/components/guides/guide-sidebar.tsx
+++ b/src/components/guides/guide-sidebar.tsx
@@ -4,20 +4,23 @@ import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
-import { Guide, Section } from '@/lib/mdx';
+import { MarkdownGroup, MarkdownSection } from '@/lib/mdx';
 import { ChevronDown } from 'lucide-react';
+import path from 'path';
 
 interface GuideSidebarProps {
-  guide: Guide;
+  guide: MarkdownGroup;
+  rootPath: string;
   className?: string;
 }
 
-const GuideSidebar: React.FC<GuideSidebarProps> = ({ guide, className }) => {
+const GuideSidebar: React.FC<GuideSidebarProps> = ({ guide, rootPath, className }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [activeSection, setActiveSection] = useState<string>('');
   const pathname = usePathname();
-  const isRootPath = pathname === `/resources/guides/${guide.slug}`;
+  const isRootPath = pathname === path.join(rootPath, guide.slug);
 
+  
   // Detect active section from pathname
   useEffect(() => {
     const pathParts = pathname.split('/');
@@ -54,7 +57,7 @@ const GuideSidebar: React.FC<GuideSidebarProps> = ({ guide, className }) => {
             <ul className="space-y-3">
               <li>
                 <Link
-                  href={`/resources/guides/${guide.slug}`}
+                  href={path.join(rootPath, guide.slug)}
                   className={cn(
                     "block py-1 hover:text-primary transition-colors",
                     isRootPath && activeSection === '' ? "text-primary font-medium" : "text-muted-foreground"
@@ -67,7 +70,7 @@ const GuideSidebar: React.FC<GuideSidebarProps> = ({ guide, className }) => {
               {guide.sections.map((section) => (
                 <li key={section.slug}>
                   <Link
-                    href={`/resources/guides/${guide.slug}/${section.slug}`}
+                    href={path.join(rootPath, guide.slug, section.slug)}
                     className={cn(
                       "block py-1 hover:text-primary transition-colors",
                       activeSection === section.slug 
@@ -91,7 +94,7 @@ const GuideSidebar: React.FC<GuideSidebarProps> = ({ guide, className }) => {
         <ul className="space-y-3">
           <li>
             <Link
-              href={`/resources/guides/${guide.slug}`}
+              href={path.join(rootPath, guide.slug)}
               className={cn(
                 "block py-1 hover:text-primary transition-colors",
                 isRootPath && activeSection === '' ? "text-primary font-medium" : "text-muted-foreground"
@@ -103,7 +106,7 @@ const GuideSidebar: React.FC<GuideSidebarProps> = ({ guide, className }) => {
           {guide.sections.map((section) => (
             <li key={section.slug}>
               <Link
-                href={`/resources/guides/${guide.slug}/${section.slug}`}
+                href={path.join(rootPath, guide.slug, section.slug)}
                 className={cn(
                   "block py-1 hover:text-primary transition-colors",
                   activeSection === section.slug 

--- a/src/components/guides/guides-list.tsx
+++ b/src/components/guides/guides-list.tsx
@@ -1,11 +1,13 @@
-import { Guide } from "@/lib/mdx";
+import { MarkdownGroup } from "@/lib/mdx";
 import GuideCard from "./guide-card";
+import path from "path";
 
 interface GuidesListProps {
-  guides: Guide[];
+  guides: MarkdownGroup[];
+  href: string;
 }
 
-const GuidesList: React.FC<GuidesListProps> = ({ guides }) => {
+const GuidesList: React.FC<GuidesListProps> = ({ guides, href }) => {
   if (guides.length === 0) {
     return (
       <div className="text-center p-8">
@@ -14,7 +16,6 @@ const GuidesList: React.FC<GuidesListProps> = ({ guides }) => {
       </div>
     );
   }
-
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
       {guides.map((guide) => (
@@ -22,7 +23,7 @@ const GuidesList: React.FC<GuidesListProps> = ({ guides }) => {
           key={guide.slug}
           title={guide.title}
           description={guide.description}
-          slug={guide.slug}
+          href={path.join(href, guide.slug)}
           author={guide.author}
           date={guide.date}
         />


### PR DESCRIPTION
Previously <Link> used hard coded value. This made it difficult for other page to use this component. So we're changing it to a variable instead.

**Note:**
- this is sub branch of [_TECH-59-Implement-a-way-to-retrieve-markdown-code-from-another-repository_](https://manitobacssa.atlassian.net/browse/TECH-59)
- I'm skipping ci because I made separate PR for each refactoring/implementation done for my feature branch, ci will run when PR  feature branch -> main 