### PR TITLE
refactored guide page to reflect generalized component [skip-ci]

### DIFF
--- a/src/app/resources/guides/[guide-slug]/[section-slug]/not-found.tsx
+++ b/src/app/resources/guides/[guide-slug]/[section-slug]/not-found.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import PageHeader from '@/components/page-header';
 import { notFound } from 'next/navigation';
-import { getGuiedBySlug } from '@/lib/mdx';
+import { getGuideBySlug } from '@/lib/mdx';
 
 export default async function SectionNotFound({ 
   params
@@ -15,7 +15,7 @@ export default async function SectionNotFound({
   }
 
   // Check if the guide exists
-  const guide = await getGuiedBySlug(params['guide-slug']);
+  const guide = await getGuideBySlug(params['guide-slug']);
   
   // If the guide itself doesn't exist, show the main not found page
   if (!guide || guide.title === 'Guide Not Found') {

--- a/src/app/resources/guides/[guide-slug]/[section-slug]/page.tsx
+++ b/src/app/resources/guides/[guide-slug]/[section-slug]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation';
 import { Metadata } from 'next';
-import { getGuiedBySlug, getGuideSection, getGuidesSlugs, markdownToHtml } from '@/lib/mdx';
+import { getGuideBySlug, getMarkdownSectionBySlug, getGuidesSlugs, markdownToHtml } from '@/lib/mdx';
 import PageHeader from '@/components/page-header';
 import GuideSidebar from '@/components/guides/guide-sidebar';
 import MarkdownContent from '@/components/guides/markdown-content';
@@ -17,7 +17,7 @@ interface SectionPageProps {
 }
 
 export async function generateMetadata({ params }: SectionPageProps): Promise<Metadata> {
-  const guide = await getGuiedBySlug(params['guide-slug']);
+  const guide = await getGuideBySlug(params['guide-slug']);
   
   if (!guide.title || guide.title === 'Guide Not Found') {
     return {
@@ -26,7 +26,7 @@ export async function generateMetadata({ params }: SectionPageProps): Promise<Me
     };
   }
   
-  const section = await getGuideSection(params['guide-slug'], params['section-slug']);
+  const section = await getMarkdownSectionBySlug(params['guide-slug'], params['section-slug']+".md", params['section-slug']);
   
   if (!section.title || section.title === 'Section Not Found') {
     return {
@@ -46,11 +46,11 @@ export async function generateStaticParams() {
   const params: { 'guide-slug': string; 'section-slug': string }[] = [];
   
   for (const guideSlug of guides) {
-    const guide = await getGuiedBySlug(guideSlug);
-    guide.sections.forEach(async (section) => {
+    const guide = await getGuideBySlug(guideSlug);
+    guide.sections.forEach(async (sections) => {
       params.push({
         'guide-slug': guideSlug,
-        'section-slug': section.slug,
+        'section-slug': sections.slug,
       });
     });
   }
@@ -59,13 +59,13 @@ export async function generateStaticParams() {
 }
 
 export default async function SectionPage({ params }: SectionPageProps) {
-  const guide = await getGuiedBySlug(params['guide-slug']);
+  const guide = await getGuideBySlug(params['guide-slug']);
   
   // Redirect to 404 if guide not found
   if (!guide.title || guide.title === 'Guide Not Found') {
     notFound();
   }
-  const section = await getGuideSection(params['guide-slug'], params['section-slug']);
+  const section = await getMarkdownSectionBySlug(params['guide-slug'], params['section-slug']+".md", params['section-slug']);
   // Redirect to 404 if section not found
   if (!section.title || section.title === 'Section Not Found') {
     notFound();
@@ -98,7 +98,7 @@ export default async function SectionPage({ params }: SectionPageProps) {
         <div className="lg:grid lg:grid-cols-3 gap-8">
           {/* Sidebar Navigation */}
           <div className="lg:col-span-1">
-            <GuideSidebar guide={guide} />
+            <GuideSidebar guide={guide} rootPath={"/resources/guides"} />
           </div>
           
           {/* Main Content */}

--- a/src/app/resources/guides/[guide-slug]/page.tsx
+++ b/src/app/resources/guides/[guide-slug]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation';
 import { Metadata } from 'next';
-import { getGuiedBySlug, getGuidesSlugs, extractHeadings, markdownToHtml } from '@/lib/mdx';
+import { getGuideBySlug, getGuidesSlugs, extractHeadings, markdownToHtml } from '@/lib/mdx';
 import PageHeader from '@/components/page-header';
 import GuideSidebar from '@/components/guides/guide-sidebar';
 import MarkdownContent from '@/components/guides/markdown-content';
@@ -13,7 +13,7 @@ interface GuidePageProps {
 }
 
 export async function generateMetadata({ params }: GuidePageProps): Promise<Metadata> {
-  const guide = await getGuiedBySlug(params['guide-slug']);
+  const guide = await getGuideBySlug(params['guide-slug']);
   
   if (!guide.title || guide.title === 'Guide Not Found') {
     return {
@@ -36,7 +36,7 @@ export async function generateStaticParams() {
 }
 
 export default async function GuidePage({ params }: GuidePageProps) {
-  const guide = await getGuiedBySlug(params['guide-slug']);
+  const guide = await getGuideBySlug(params['guide-slug']);
   
   // Redirect to 404 if guide not found
   if (!guide.title || guide.title === 'Guide Not Found') {
@@ -64,7 +64,7 @@ export default async function GuidePage({ params }: GuidePageProps) {
         <div className="lg:grid lg:grid-cols-3 gap-8">
           {/* Sidebar Navigation */}
           <div className="lg:col-span-1">
-            <GuideSidebar guide={guide} />
+            <GuideSidebar guide={guide} rootPath={"/resources/guides"} />
           </div>
           
           {/* Main Content */}

--- a/src/app/resources/guides/page.tsx
+++ b/src/app/resources/guides/page.tsx
@@ -25,7 +25,7 @@ export default async function GuidesPage() {
           </p>
         </div>
 
-        <GuidesList guides={guides} />
+        <GuidesList guides={guides} href="/resources/guides" />
       </div>
     </main>
   );


### PR DESCRIPTION
[Previously, guide page was refactored into having generalized variable href instead of hard-coded one](https://github.com/umanitoba-cssa/cssa-website-next/pull/68). We are changing guide page to reflect these changes.

**Note:**
- this is sub branch of [_TECH-59-Implement-a-way-to-retrieve-markdown-code-from-another-repository_](https://manitobacssa.atlassian.net/browse/TECH-59)
- I'm skipping ci because I made separate PR for each refactoring/implementation done for my feature branch, ci will run when PR  feature branch -> main 