### PR TITLE
TECH 32: Change color of text in student guides

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 :root {
-    --foreground-rgb: 255, 255, 255;
+    --foreground-rgb: 222, 222, 222;
     --foreground: 255, 255, 255;
     --background: 3 13 31;
 

--- a/src/components/page-header.tsx
+++ b/src/components/page-header.tsx
@@ -8,14 +8,14 @@ export default function PageHeader({ title, image }: { title: string; image: str
                     <Image className="relative object-cover" fill src={image} alt={title} />
                     <div className="w-full h-full bg-opacity-30 bg-black p-12 relative">
                         <div className="container z-10">
-                            <h2 className="border-l-4 p-8 border-cssa-gold">{title}</h2>
+                            <h2 className="border-l-4 p-8 border-cssa-gold text-white">{title}</h2>
                         </div>
                     </div>
                 </div>
             </div>
             <div className="mobile-only flex flex-col gap-4">
                 <div className="container">
-                    <h2 className="text-3xl">{title}</h2>
+                    <h2 className="text-3xl text-white">{title}</h2>
                 </div>
                 <div className="w-full h-48 relative">
                     <Image className="relative object-cover" fill src={image} alt={title} />


### PR DESCRIPTION

- Updated the colour of text for the overall website from (255,255,255) -> (222,222,222)
- Kept the Page Header to the original shade of white
- Left is after, right is before
<img width="1692" height="846" alt="Screenshot 2025-12-12 at 7 42 27 PM" src="https://github.com/user-attachments/assets/aa51b1a2-5dd0-4a7b-bea6-7a5c725d5045" />

Home page looks like this:
<img width="1206" height="780" alt="Screenshot 2025-12-12 at 10 29 20 PM" src="https://github.com/user-attachments/assets/3511d7eb-88db-4b5c-b90f-5b940762ade2" />
