### PR TITLE
Tech 104 Fix inconsistent event photo page header

### DIFF
--- a/src/components/event-photo-page.tsx
+++ b/src/components/event-photo-page.tsx
@@ -4,7 +4,6 @@ import BlockHeader from '@/components/block-header';
 import { RecentEvents, OlderEvents } from '@/data/events';
 import fs from 'fs';
 import path from 'path';
-import React from 'react';
 
 interface EventPhotoPageProps {
     eventKey: string;
@@ -26,7 +25,9 @@ export default async function EventPhotoPage({
     }
 
     const dir = path.join(process.cwd(), 'public' + photoDir);
-    const images = fs.readdirSync(dir);
+    const images = fs.readdirSync(dir).sort((a, b) => {
+        return a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' });
+    });
 
     if (!images[headerImageIdx]) {
         throw new Error(`Header image index ${headerImageIdx} out of bounds for ${photoDir}`);


### PR DESCRIPTION
## Jira Issue Reference
- **Jira Issue:** [TECH-104](https://manitobacssa.atlassian.net/browse/TECH-104)

## Type of Change
- [x] Bug Fix
- [ ] Feature
- [ ] Update / Improvement
- [ ] Documentation only
- [ ] Other:

## Description

### `src/components/event-photo-page.tsx`
- **What changed:**
Added sorting to the file reading, so that files are loaded in a consistent ordering. It uses a locale aware sort (should use whatever alphabet ordering the server uses) as well as treating numbers as numbers instead of characters, so `image2`, `image20`, and `image12` would be put in order: `image2`, `image12`, `image20`.
- **Why it changed:**
As per the ticket description, depending on the platform, the development environment sometimes loads a different header image compared to the server. See [on the server](https://umanitobacssa.ca/events/bonfire-2024) vs [local](http://localhost:3000/events/bonfire-2024).

## (Optional) Before and After Images 
**Before:**
<img width="1898" height="789" alt="image" src="https://github.com/user-attachments/assets/aeb0c113-5eaa-4195-bf61-056d55d6ad00" />

<img width="1900" height="769" alt="image" src="https://github.com/user-attachments/assets/61d25d9a-a70c-42a9-a484-9d37e9dd6de4" />

**After:**

<img width="1907" height="766" alt="image" src="https://github.com/user-attachments/assets/36af73cc-ded5-46a2-a856-99b407b6b21b" />

<img width="1900" height="769" alt="image" src="https://github.com/user-attachments/assets/61d25d9a-a70c-42a9-a484-9d37e9dd6de4" />

## Testing 
Ensure you've tested the following, if applicable. Select all that apply.
- [x] Mobile/Desktop View
- [ ] Accessibility
- [x] Functionality
- [ ] Edge cases
- [ ] Not tested
- [ ] Other testing:

---
> **Note:** Ensure you put **`[skip ci]`** in the code review title if these are changes that shouldn’t run the CI, such as documentation changes


[TECH-104]: https://manitobacssa.atlassian.net/browse/TECH-104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ