### PR TITLE
chore:added caching after 1 day for Lounge page

### DIFF
--- a/src/app/lounge/page.tsx
+++ b/src/app/lounge/page.tsx
@@ -1,3 +1,6 @@
+export const revalidate = 86400;
+// 86400 seconds = 60 * 60 * 24 , which is 1 day
+
 import { getLoungeMenu } from '@/api/sheets';
 import BlockHeader from '@/components/block-header';
 import PageHeader from '@/components/page-header';


### PR DESCRIPTION
## Jira Issue Reference
- **Jira Issue:** [TECH-119](https://manitobacssa.atlassian.net/browse/TECH-119)

## Type of Change
- [ ] Bug Fix
- [ ] Feature
- [x] Update / Improvement
- [ ] Documentation only
- [ ] Other:

## Description

### `src/app/lounge/page.tsx.`
- **What changed:**
Added revalidation after 1 day just for the lounge page
- **Why it changed:**
Lounge menu items did not automatically get updated prior to this change
## (Optional) Before and After Images 
**Before:**

**After:**

## Testing 
Ensure you've tested the following, if applicable. Select all that apply.
- [ ] Mobile/Desktop View
- [ ] Accessibility
- [x] Functionality
- [ ] Edge cases
- [ ] Not tested
- [ ] Other testing:

---
> **Note:** Ensure you put **`[skip ci]`** in the commit message AND code review title if these are changes that shouldn’t run the CI, such as documentation changes


[TECH-119]: https://manitobacssa.atlassian.net/browse/TECH-119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ