### PR TITLE
fix a bug where upcoming event does not show when eventdate and today…

### DIFF
--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -106,7 +106,7 @@ export interface IUpcomingEvent {
 const AllUpcomingEvents: IUpcomingEvent[] = [
     {
         title: 'Design & Craft Sprint (Case Competition)',
-        date: 'March 21, 2026',
+        date: 'April 4, 2026',
         description:
             'Love problem-solving? Join us for a case competition where teams of five compete to solve a technical challenge.',
         image: '/img/case-competition/banner.png',
@@ -116,7 +116,10 @@ const AllUpcomingEvents: IUpcomingEvent[] = [
 ];
 
 export const UpcomingEvents: IUpcomingEvent[] = AllUpcomingEvents.filter((event) => {
-    return new Date(event.date.replace(/(\d+)(st|nd|rd|th)/, '$1')) > new Date();
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const eventDate = new Date(event.date.replace(/(\d+)(st|nd|rd|th)/, '$1'));
+    return eventDate >= today;
 }).sort((a, b) => {
     // sort by time
     return (

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -106,7 +106,7 @@ export interface IUpcomingEvent {
 const AllUpcomingEvents: IUpcomingEvent[] = [
     {
         title: 'Design & Craft Sprint (Case Competition)',
-        date: 'April 4, 2026',
+        date: 'March 21, 2026',
         description:
             'Love problem-solving? Join us for a case competition where teams of five compete to solve a technical challenge.',
         image: '/img/case-competition/banner.png',


### PR DESCRIPTION
… is the same

## Jira Issue Reference
- **Jira Issue:** [TECH-#147](link)

## Type of Change
- [x] Bug Fix
- [ ] Feature
- [ ] Update / Improvement
- [ ] Documentation only
- [ ] Other:

## Description
When the upcoming event's date is the same as today, it won't show up in landing page. This change fix it.

### `path/to/file.txt`
- **What changed:**

- **Why it changed:**

## (Optional) Before and After Images 
**Before:**
<img width="1471" height="531" alt="image" src="https://github.com/user-attachments/assets/3dd749c7-f26b-437f-a1e6-3cb97fb74db6" />

**After:**
<img width="1471" height="531" alt="Screenshot from 2026-04-04 01-03-38" src="https://github.com/user-attachments/assets/79b7ce31-f0e6-4ee5-9c23-a3f34892c21c" />

## Testing 
Ensure you've tested the following, if applicable. Select all that apply.
- [ ] Mobile/Desktop View
- [ ] Accessibility
- [ ] Functionality
- [ ] Edge cases
- [ ] Not tested
- [x] Other testing:

---
> **Note:** Ensure you put **`[skip ci]`** in the commit message AND code review title if these are changes that shouldn’t run the CI, such as documentation changes
