### PR TITLE
TECH-151: Remove election 2026 from routes or nav bar

### DIFF
--- a/src/app/elections/page.tsx
+++ b/src/app/elections/page.tsx
@@ -13,15 +13,6 @@ export default function Elections() {
                 <div className="flex flex-col gap-4">
                     <BlockHeader title="Election Information" />
                     <a
-                        href={`https://docs.google.com/document/d/1f4LfCH8aRxPPb0OgNE_2stsrRsJYH7hd/edit`}>
-                        <Button
-                            className="w-full"
-                            variant="default"
-                            size="lg">
-                            Election Package
-                        </Button>
-                    </a>
-                    <a
                         href={`https://github.com/umanitoba-cssa/constitution/blob/main/Constitution.md`}>
                         <Button
                             className="w-full"

--- a/src/data/routes.ts
+++ b/src/data/routes.ts
@@ -7,12 +7,6 @@ interface IRoute {
 
 export const Routes: IRoute[] = [
     {
-        title: 'Elections 2026',
-        href: '/elections',
-        image: '/img/backgrounds/home.jpg',
-        showInNavbar: true,
-    },
-    {
         title: 'Home',
         href: '/',
         image: '/img/backgrounds/home.jpg',


### PR DESCRIPTION
## Jira Issue Reference
- **Jira Issue:** [TECH-151](https://manitobacssa.atlassian.net/browse/TECH-151)

## Type of Change
- [ ] Bug Fix
- [ ] Feature
- [ ] Update / Improvement
- [ ] Documentation only
- [x] Other: Maintenance

## Description

### `src/data/routes.ts`
- **What changed:** Remove election 2026 from routes or nav bar

- **Why it changed:** Because elections has passed. But kept the lounge redirect as application is still open

## (Optional) Before and After Images 
**Before:**

**After:**

## Testing 
Ensure you've tested the following, if applicable. Select all that apply.
- [x] Mobile/Desktop View
- [ ] Accessibility
- [ ] Functionality
- [ ] Edge cases
- [ ] Not tested
- [ ] Other testing:

---
> **Note:** Ensure you put **`[skip ci]`** in the commit message AND code review title if these are changes that shouldn’t run the CI, such as documentation changes


[TECH-151]: https://manitobacssa.atlassian.net/browse/TECH-151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ