### PR TITLE
[TECH-193] Let CI jobs run in parallel

### DIFF
--- a/.github/workflows/cd-ci-pipeline.yml
+++ b/.github/workflows/cd-ci-pipeline.yml
@@ -51,9 +51,8 @@ jobs:
           echo "ENVIRONMENT: ${{ steps.set-port.outputs.ENVIRONMENT }}"
           echo "IMAGE_NAME: ${{ steps.set-port.outputs.IMAGE_NAME }}"
           echo "DEPLOY_URL: ${{ steps.set-port.outputs.DEPLOY_URL }}"
-  lint:
+  eslint:
     runs-on: ubuntu-latest
-    needs: set-port
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -67,12 +66,24 @@ jobs:
       - name: Run ESLint
         run: bun run eslint .
 
+  prettier:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --ignore-scripts --frozen-lockfile
+
       - name: Run Prettier check
         run: bun run prettier --check .
 
   build:
     runs-on: ubuntu-latest
-    needs: [set-port, lint]
+    needs: set-port
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -132,7 +143,7 @@ jobs:
           retention-days: 14
   deploy:
     runs-on: [self-hosted, webhost]
-    needs: [set-port, lint, build]
+    needs: [set-port, eslint, prettier, build]
     environment:
       name: ${{ needs.set-port.outputs.ENVIRONMENT }}
       url: ${{ needs.set-port.outputs.DEPLOY_URL }}


### PR DESCRIPTION
## Type of Change
- [ ] Bug Fix
- [ ] Feature
- [x] Update / Improvement
- [ ] Documentation only
- [ ] Other:

## Description

### `.github/workflows/cd-ci-pipeline.yml`
- **What changed:**

Broke up `lint` step into `eslint` and `prettier` steps and let them run in parallel with `set-port`.

- **Why it changed:**

To speed up the CI/CD pipeline, went from ~7mins to still ~7mins because build and deploy are the biggest steps and they depend on each other and also have some variance in the time they take, but it should save on average ~30s because lint doesn't block build anymore.

## Testing 
Ensure you've tested the following, if applicable. Select all that apply.
- [ ] Mobile/Desktop View
- [ ] Accessibility
- [ ] Functionality
- [ ] Edge cases
- [ ] Not tested
- [x] Other testing:

Ran the CI/CD pipeline on this branch [here](https://github.com/umanitoba-cssa/cssa-website-next/actions/runs/31511178946), the build dependency graph now shows that more can be run in parallel:

<img width="1578" height="549" alt="image" src="https://github.com/user-attachments/assets/bc4802f2-9888-4f1e-acf0-816b95428bb8" />

---
> **Note:** Ensure you put **`[skip ci]`** in the commit message AND code review title if these are changes that shouldn’t run the CI, such as documentation changes
