### PR TITLE
WEB-186 Add local build when missing credentials

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@
 FROM oven/bun:1.3.14 AS builder
 WORKDIR /usr/src/app
 
+# Local Docker override: set to "true" for local builds
+ARG LOCAL_DEV=false
+ENV LOCAL_DEV=${LOCAL_DEV}
+
 # Public / client-side variables
 ARG NEXT_PUBLIC_RECAPTCHA_SITE_KEY
 ENV NEXT_PUBLIC_RECAPTCHA_SITE_KEY=${NEXT_PUBLIC_RECAPTCHA_SITE_KEY}
@@ -50,6 +54,9 @@ RUN --mount=type=secret,id=YOUTUBE_API_KEY \
 # Production stage
 FROM oven/bun:1.3.14-slim AS production
 WORKDIR /usr/src/app
+
+ARG LOCAL_DEV=false
+ENV LOCAL_DEV=${LOCAL_DEV}
 
 ARG NEXT_PUBLIC_RECAPTCHA_SITE_KEY
 ENV NEXT_PUBLIC_RECAPTCHA_SITE_KEY=${NEXT_PUBLIC_RECAPTCHA_SITE_KEY}

--- a/src/api/calendar.ts
+++ b/src/api/calendar.ts
@@ -16,6 +16,15 @@ export async function getCalendarEvents(opts: {
     timeMin: string;
     timeMax: string;
 }): Promise<IEventLink[]> {
+    const PROD_ENV = process.env.NODE_ENV === 'production' && process.env.LOCAL_DEV !== 'true';
+    // If credentials are missing, skip calling Calendar API.
+    if (!process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL || !process.env.GOOGLE_PRIVATE_KEY) {
+        const msg = 'Missing Google service account credentials';
+        if (PROD_ENV) throw new Error(msg);
+        console.warn(msg + '; skipping Calendar API');
+        return [];
+    }
+
     const auth = new Auth.GoogleAuth({
         scopes: ['https://www.googleapis.com/auth/calendar.readonly'],
         credentials: {
@@ -58,9 +67,12 @@ export async function getCalendarEvents(opts: {
 }
 
 export async function getEvents() {
+    const PROD_ENV = process.env.NODE_ENV === 'production' && process.env.LOCAL_DEV !== 'true';
     const calendarId = process.env.GOOGLE_CALENDAR_ID;
     if (!calendarId) {
-        console.warn('Missing env CALENDAR_ID');
+        const msg = 'Missing env CALENDAR_ID';
+        if (PROD_ENV) throw new Error(msg);
+        console.warn(msg);
         return [];
     }
 

--- a/src/api/sheets.ts
+++ b/src/api/sheets.ts
@@ -8,6 +8,15 @@ interface ICanteenItem {
 }
 
 export async function getSheetsCells(sheetId: string, range: string) {
+    const PROD_ENV = process.env.NODE_ENV === 'production' && process.env.LOCAL_DEV !== 'true';
+    // If credentials are missing, skip calling Google Sheets
+    if (!process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL || !process.env.GOOGLE_PRIVATE_KEY) {
+        const msg = 'Missing Google service account credentials';
+        if (PROD_ENV) throw new Error(msg);
+        console.warn(msg + '; skipping Sheets API');
+        return null;
+    }
+
     const auth = new Auth.GoogleAuth({
         scopes: ['https://www.googleapis.com/auth/spreadsheets.readonly'],
         credentials: {
@@ -28,14 +37,21 @@ export async function getSheetsCells(sheetId: string, range: string) {
 }
 
 export async function getLoungeMenu() {
+    const PROD_ENV = process.env.NODE_ENV === 'production' && process.env.LOCAL_DEV !== 'true';
     if (!process.env.CANTEEN_SHEEET_ID) {
-        throw new Error('Missing environment variable CANTEEN_SHEEET_ID');
+        const msg = 'Missing environment variable CANTEEN_SHEEET_ID';
+        if (PROD_ENV) throw new Error(msg);
+        console.warn(msg + '; returning empty menu');
+        return {} as Record<string, ICanteenItem[]>;
     }
 
     const data = await getSheetsCells(process.env.CANTEEN_SHEEET_ID, "'Website CSV Export'!A:C");
 
     if (!data) {
-        throw new Error('Failed to fetch canteen data');
+        const msg = 'Failed to fetch canteen data';
+        if (PROD_ENV) throw new Error(msg);
+        console.warn(msg + '; returning empty menu');
+        return {} as Record<string, ICanteenItem[]>;
     }
 
     const objects: ICanteenItem[] = data.slice(1).map((row) => ({

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -21,6 +21,8 @@ import { getEvents } from '@/api/calendar';
 
 export default async function Events() {
     const events = await getEvents();
+    const isLocalDockerBuild = process.env.LOCAL_DEV === 'true';
+    const calendarUnavailable = events.length === 0 && isLocalDockerBuild;
 
     const recentEvents = Array.from(RecentEvents.values()).map((link, index) => {
         return (
@@ -143,7 +145,11 @@ export default async function Events() {
                     <BlockHeader title="Calendar" />
                     <p>Calendar View of events ran by the CSSA.</p>
 
-                    <CalendarClientWrapper events={events} />
+                    {calendarUnavailable ? (
+                        <div className="p-4 text-cssa-gold">Failed to fetch calendar events.</div>
+                    ) : (
+                        <CalendarClientWrapper events={events} />
+                    )}
                 </div>
             </div>
         </main>

--- a/src/app/lounge/page.tsx
+++ b/src/app/lounge/page.tsx
@@ -15,8 +15,11 @@ import {
 
 export default async function Lounge() {
     const menu = await getLoungeMenu();
+    const isLocalDockerBuild = process.env.LOCAL_DEV === 'true';
+    const menuCategories = Object.keys(menu);
+    const loungeMenuUnavailable = isLocalDockerBuild && menuCategories.length === 0;
 
-    const menuItems = Object.keys(menu).map((category) => {
+    const menuItems = menuCategories.map((category) => {
         const rows = menu[category].map((item) => {
             return (
                 <TableRow key={item.Item}>
@@ -63,7 +66,11 @@ export default async function Lounge() {
                     id="lounge-menu"
                     className="flex flex-col gap-8">
                     <BlockHeader title="Lounge Canteen Menu" />
-                    <div className="flex flex-col gap-8">{menuItems}</div>
+                    {loungeMenuUnavailable ? (
+                        <div className="p-4 text-cssa-gold">Failed to fetch lounge menu.</div>
+                    ) : (
+                        <div className="flex flex-col gap-8">{menuItems}</div>
+                    )}
                 </div>
             </div>
         </main>


### PR DESCRIPTION
## Github Issue Reference
- **Github Issue:** [WEB-186](https://github.com/umanitoba-cssa/cssa-website-next/issues/186)

## Type of Change
- [ ] Bug Fix
- [ ] Feature
- [x] Update / Improvement
- [ ] Documentation only
- [ ] Other:

## Description
- Add an optional local build because of credentials missing.
- I did `export LOCAL_DEV=true` in my terminal to set it to true in my environment since I'm not sure how to set it in docker

- **What changed:**
Check if current environment is production, and if it is, throw error whenever credentials are missing. If it's local, add a log and return empty state. 
For lounge and event `page.tsx`, display a `failed to fetch...` message for local dev.
Add a parameter in the docker file for `LOCAL_DEV` that is set to false on default.
- **Why it changed:**
Cannot run build commands locally when trying to run `npm run build`.

## (Optional) Before and After Images 
**After:**
<img width="348" height="138" alt="Screenshot 2026-08-17 at 11 12 16 PM" src="https://github.com/user-attachments/assets/ebdd2f3f-2e9d-4380-9cc3-0f5e01c228cf" />
<img width="416" height="182" alt="Screenshot 2026-08-17 at 11 12 10 PM" src="https://github.com/user-attachments/assets/841a595d-6b19-4fe9-9e0b-9d3420c2eaca" />

<img width="500" height="101" alt="Screenshot 2026-08-17 at 11 11 47 PM" src="https://github.com/user-attachments/assets/98af629e-07c2-434c-a21c-36d2b1babc27" />

## Testing 
Ensure you've tested the following, if applicable. Select all that apply.
- [ ] Mobile/Desktop View
- [ ] Accessibility
- [x] Functionality
- [ ] Edge cases
- [ ] Not tested
- [ ] Other testing:

---
> **Note:** Ensure you put **`[skip ci]`** in the commit message AND code review title if these are changes that shouldn’t run the CI, such as documentation changes
